### PR TITLE
`dependencies` is not part of `galaxy_info`

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,4 +28,4 @@ galaxy_info:
     - nvm
     - npm
     - gulpjs
-  dependencies: []
+dependencies: []


### PR DESCRIPTION
`ansible-galaxy install git+https://github.com/ansible-role/ansible-role.nodejs.git` returns the following error:

```
ansible-galaxy install git+https://github.com/ansible-role/ansible-role.nodejs.git

- executing: git clone https://github.com/ansible-role/ansible-role.nodejs.git ansible-role.nodejs
- executing: git archive --prefix=ansible-role.nodejs/ --output=/var/folders/_t/6y4bty0561l0_850tkdpd5cm0000gp/T/tmp
gO8KXY.tar master
- extracting ansible-role.nodejs to ./library_roles/ansible-role.nodejs
- ansible-role.nodejs was installed successfully
Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 957, in <module>
    main()
  File "/usr/local/bin/ansible-galaxy", line 951, in main
    fn(args, options, parser)
  File "/usr/local/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```

This fix resolved the above issue.
